### PR TITLE
Remove QuickCheck and quickcheck-instances dependency

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,9 @@
+0.2
+===
+
+- removed SomeArray and Arbitrary instances
+- removed QuickCheck and quickcheck-instances dependencies
+
 0.1
 ===
 

--- a/harpie.cabal
+++ b/harpie.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: harpie
-version: 0.1.4.0
+version: 0.2.0.0
 license: BSD-3-Clause
 license-file: LICENSE
 copyright: Tony Day (c) 2016-2024
@@ -146,13 +146,11 @@ library
   import: ghc2024-stanza
   hs-source-dirs: src
   build-depends:
-    QuickCheck >=2.14 && <2.18,
     adjunctions >=4.0 && <5,
     base >=4.18 && <5,
     distributive >=0.4 && <0.7,
     first-class-families >=0.8.1 && <0.9,
     prettyprinter >=1.7 && <1.8,
-    quickcheck-instances >=0.3.31 && <0.4,
     random >=1.2 && <1.4,
     vector >=0.12.3 && <0.14,
     vector-algorithms >=0.9.0 && <0.10,

--- a/src/Harpie/Fixed.hs
+++ b/src/Harpie/Fixed.hs
@@ -33,8 +33,6 @@ module Harpie.Fixed
     FromVector (..),
     toDynamic,
     with,
-    SomeArray (..),
-    someArray,
 
     -- * Shape Access
     shape,
@@ -213,11 +211,8 @@ import Harpie.Sort
 import Prettyprinter hiding (dot, fill)
 import System.Random hiding (uniform)
 import System.Random.Stateful hiding (uniform)
-import Test.QuickCheck hiding (tabulate, vector)
-import Test.QuickCheck.Instances.Natural ()
 import Unsafe.Coerce
 import Prelude as P hiding (cycle, drop, length, repeat, sequence, take, zipWith)
-import Prelude qualified
 
 -- $setup
 --
@@ -534,35 +529,6 @@ with ::
   r
 with d f =
   withSomeSNats (fromIntegral <$> A.shape d) $ \(SNats :: SNats s) -> withKnownNats (SNats @s) (f (array @s (A.asVector d)))
-
--- | Sigma type for an 'Array'
---
--- A fixed Array where shape was unknown at runtime.
---
--- The library design encourages the use of value-level shape arrays (in @Harpie.Array@) via 'toDynamic' in preference to dependent-type styles of coding. In particular, no attempt has been made to prove to the compiler that a particular Shape (resulting from any of the supplied functions) exists. Life is short.
---
--- >> P.take 4 <$> sample' arbitrary :: IO [SomeArray Int]
--- >> [SomeArray SNats @'[] [0],SomeArray SNats @'[0] [],SomeArray SNats @[1, 1] [1],SomeArray SNats @[5, 1, 4] [2,1,0,2,-6,0,5,6,-1,-4,0,5,-1,6,4,-6,1,0,3,-1]]
-data SomeArray a = forall s. SomeArray (SNats s) (Array s a)
-
-deriving instance (Show a) => Show (SomeArray a)
-
-instance Functor SomeArray where
-  fmap f (SomeArray sn a) = SomeArray sn (fmap f a)
-
-instance Foldable SomeArray where
-  foldMap f (SomeArray _ a) = foldMap f a
-
--- | Construct a SomeArray
-someArray :: forall s t a. (FromVector t a) => SNats s -> t -> SomeArray a
-someArray s t = SomeArray s (Array (asVector t))
-
-instance (Arbitrary a) => Arbitrary (SomeArray a) where
-  arbitrary = do
-    s <- arbitrary :: Gen [Small Nat]
-    let s' = Prelude.take 3 (getSmall <$> s)
-    v <- V.replicateM (product (Prelude.fromIntegral <$> s')) arbitrary
-    withSomeSNats s' $ \sn -> pure (someArray sn v)
 
 -- | Get shape of an Array as a value.
 --


### PR DESCRIPTION
Remove QuickCheck and quickcheck-instances dependency, bumping to 0.2.0.0 (major API change: removed SomeArray)